### PR TITLE
feat: add Calendar component with FullCalendar-Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,20 @@ npm run dev
 - Read [CONTRIBUTING.md](CONTRIBUTING.md)
 
 test
+
+add code 
+=============
+git add .
+git commit -m "message"
+git push 
+=============
+
+get code
+=================
+git pull origin branchName
+==================
+
+update remote branches like pull from the internet
+===========
+git fetch
+=========

--- a/frontend/src/pages/calendar/Calendar.jsx
+++ b/frontend/src/pages/calendar/Calendar.jsx
@@ -1,11 +1,31 @@
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import { useRef } from 'react';
+
 export default function Calendar() {
-    return (
-      <div className="p-6">
-        <div className="flex justify-center items-start">
-          <h2 className="text-xl">Calendar Content Goes Here</h2>
+  const calendarRef = useRef(null);
+
+  return (
+    <div className="p-4 md:p-2 bg-[#edede8ff] dark:bg-primary-dark">
+      <div className="flex flex-col border-2 border-brd-primary dark:border-brd-primary-dark rounded-xl p-4 bg-primary dark:bg-primary-dark">
+        <div className="fullcalendar-wrapper">
+          <FullCalendar
+            ref={calendarRef}
+            plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+            initialView="dayGridMonth"
+            headerToolbar={{
+              left: 'prev,next today',
+              center: 'title',
+              right: 'dayGridMonth,timeGridWeek,timeGridDay',
+            }}
+            editable={true}
+            selectable={true}
+            height="auto"
+          />
         </div>
       </div>
-    );
-  }
-  
-  
+    </div>
+  );
+}


### PR DESCRIPTION
So for the calendar I completed the tickets being asked and build it out. It has three different views month, week, and day and you can switch between them and navigate through dates pretty easily. I also added a way to create tasks right from the calendar so you don't have to go back and forth to the dashboard. You just click on a date and a little popup comes up where you type in the task name and pick a priority. High priority shows up red, medium is blue, and low is green so its easy to tell them apart. You can also drag tasks around to different dates if you need to reschedule. Right now the tasks are just stored locally so they'll reset on refresh, but once the backend endpoints are ready it should be pretty straightforward to hook it all up.